### PR TITLE
Set application tag equal to the project ID

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-    <application>YOUR_PROJECT_ID</application>
+    <application>codeutaskforce2018</application>
     <version>1</version>
     <threadsafe>false</threadsafe>
     <sessions-enabled>true</sessions-enabled>


### PR DESCRIPTION
All I did was set the application tag in src/main/webapp/WEB-INF/appengine-web.xml to codeutaskforce2018 because that is our project ID (The ID was created in the Google Cloud Platform).